### PR TITLE
Fix/supply calculation

### DIFF
--- a/src/rts/engine/CommandableManager.js
+++ b/src/rts/engine/CommandableManager.js
@@ -30,11 +30,7 @@ export default class CommandableManager {
             });
         };
 
-        this.teams = {};
-
         teams.forEach((team, index) => {
-            this.teams[team.id] = team;
-
             addStartingUnits(team, map.startingUnits[index]);
             addStartingStructures(team, map.startingStructures[index]);
             team.unitSpawnPosition = map.unitSpawnPositions[index];
@@ -43,10 +39,9 @@ export default class CommandableManager {
 
     addUnit(team, unitSpec, position, usedSupplyAlreadyUpdated = false) {
         const unit = this.unitCreator.create(unitSpec, position);
-        unit.team = team;
 
-        this.units[unit.id] = unit;
-        this.teams[unit.team.id].units[unit.id] = unit;
+        unit.team = team;
+        team.units[unit.id] = unit;
 
         team.usedSupply += usedSupplyAlreadyUpdated ? 0 : unitSpec.cost.supply;
 
@@ -55,10 +50,9 @@ export default class CommandableManager {
 
     addStructure(team, structureSpec, position) {
         const structure = this.structureCreator.create(structureSpec, position);
-        structure.team = team;
 
-        this.structures[structure.id] = structure;
-        this.teams[structure.team.id].structures[structure.id] = structure;
+        structure.team = team;
+        team.structures[structure.id] = structure;
 
         return structure;
     }
@@ -66,8 +60,7 @@ export default class CommandableManager {
     removeUnit(unit) {
         unit.clearCommands();
 
-        delete this.units[unit.id];
-        delete this.teams[unit.team.id].units[unit.id];
+        delete unit.team.units[unit.id];
 
         unit.team.usedSupply -= unit.specs.cost.supply;
     }
@@ -75,8 +68,7 @@ export default class CommandableManager {
     removeStructure(structure) {
         structure.clearCommands();
 
-        delete this.structures[structure.id];
-        delete this.teams[structure.team.id].structures[structure.id];
+        delete structure.team.structures[structure.id];
 
         structure.team.supply -= structure.specs.providesSupply || 0;
     }

--- a/src/rts/engine/CommandableManager.js
+++ b/src/rts/engine/CommandableManager.js
@@ -81,11 +81,6 @@ export default class CommandableManager {
         structure.team.supply -= structure.specs.providesSupply || 0;
     }
 
-    remove(commandable) {
-        this.removeUnit(commandable);
-        this.removeStructure(commandable);
-    }
-
     structureProducedUnit(structure, unitSpec) {
         return this.addUnit(structure.team, unitSpec, structure.team.unitSpawnPosition, true);
     }

--- a/src/rts/engine/CommandableManager.js
+++ b/src/rts/engine/CommandableManager.js
@@ -58,6 +58,10 @@ export default class CommandableManager {
     }
 
     removeUnit(unit) {
+        if (!unit.team.units[unit.id]) {
+            return;
+        }
+
         unit.clearCommands();
 
         delete unit.team.units[unit.id];
@@ -66,6 +70,10 @@ export default class CommandableManager {
     }
 
     removeStructure(structure) {
+        if (!structure.team.structures[structure.id]) {
+            return;
+        }
+
         structure.clearCommands();
 
         delete structure.team.structures[structure.id];

--- a/src/rts/engine/Engine.js
+++ b/src/rts/engine/Engine.js
@@ -232,16 +232,20 @@ export default class Engine {
 
             const didKill = AttackEngine.applyAttack(unit, target);
             if (didKill) {
-                this.tickCleanupTasks.push(() => {
-                    this.commandableManager.remove(target);
-                    this.simpleVision.commandableRemoved(target);
-                });
                 switch (target.type) {
                     case 'unit':
-                        this.scoreCounter.unitKilled(unit.team.id, target.specs);
+                        this.tickCleanupTasks.push(() => {
+                            this.scoreCounter.unitKilled(unit.team.id, target.specs);
+                            this.commandableManager.removeUnit(target);
+                            this.simpleVision.commandableRemoved(target);
+                        });
                         break;
                     case 'structure':
-                        this.scoreCounter.structureKilled(unit.team.id, target.specs);
+                        this.tickCleanupTasks.push(() => {
+                            this.scoreCounter.structureKilled(unit.team.id, target.specs);
+                            this.commandableManager.removeStructure(target);
+                            this.simpleVision.commandableRemoved(target);
+                        });
                         break;
                     default:
                         throw Error(`Invalid target type: ${target.type}`);

--- a/src/rts/engine/Engine.js
+++ b/src/rts/engine/Engine.js
@@ -215,9 +215,7 @@ export default class Engine {
         const calcFinishedTick = () => {
             return this.tick + unit.specs.weapon.cooldown;
         };
-        const onReceive = () => {
-            return true;
-        };
+        const onReceive = () => true;
         const onStart = () => {
             const isWithinRange = Vectors.absoluteDistance(unit.position, target.position) <= unit.specs.weapon.range;
             if (!isWithinRange) {


### PR DESCRIPTION
Prevent removing units/structures more than once (leads to incorrect supply calculation)

- Remove redundanly managed data in CommandableManager
- Specifically remove either units or structures